### PR TITLE
`polyStroke` and `polyFill`

### DIFF
--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -30,8 +30,8 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
   
   line (x1, y1, x2, y2, c) {
     line({
-      Math.floor(x1), Math.floor(y1),
-      Math.floor(x2), Math.floor(y2),
+      x1: Math.floor(x1), y1: Math.floor(y1),
+      x2: Math.floor(x2), y2: Math.floor(y2),
       ctx,
       color: colors.one(c)
     })

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -30,11 +30,11 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
   
   line (x1, y1, x2, y2, c) {
     line({
-	  Math.floor(x1), Math.floor(y1),
-	  Math.floor(x2), Math.floor(y2),
-	  ctx,
-	  color: colors.one(c)
-	})
+      Math.floor(x1), Math.floor(y1),
+      Math.floor(x2), Math.floor(y2),
+      ctx,
+      color: colors.one(c)
+    })
   },
 
   print (x, y, letters, c) {

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -102,14 +102,14 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         x1: Math.round(new_points[i - 1][0]), y1: Math.round(new_points[i - 1][1]),
         x2: Math.round(new_points[i][0]), y2: Math.round(new_points[i][1]),
         ctx,
-        color: c
+        color: colors.one(c)
       })
     }
     line({
       x1: Math.round(new_points[new_points.length - 1][0]), y1: Math.round(new_points[new_points.length - 1][1]),
       x2: Math.round(new_points[0][0]), y2: Math.round(new_points[0][1]),
       ctx,
-      color: c
+      color: colors.one(c)
     })
   },
 

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -105,6 +105,12 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         color: c
       })
     }
+    line({
+      x1: new_points[new_points.length - 1][0], y1: new_points[new_points.length - 1][1],
+      x2: new_points[0][0], y2: new_points[0][1],
+      ctx,
+      color: c
+    })
   },
 
   circStroke (x, y, r, c) {

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -89,31 +89,29 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     ctx.fillRect(Math.floor(x), Math.floor(y), Math.floor(w), Math.floor(h))
   },
 
-  polyStroke (points, c) {
+  polyStroke (points, ...args) {
     if (!points.length) {
       return
     }
+	let c = args[args.length - 1]
+	let new_points
+	switch(args.length) {
+	  case 1:
+	    new_points = points.map(p => [...p])
+		break;
+	  case 2:
+	    let xs = points.map(p => p[0])
+		let ys = points.map(p => p[1])
+		let min_x = 
+		new_points = points.map(p => [p[0]])
+	}
     for (let i = 1; i < points.length; i++) {
 	  canvasAPI({ ctx, width: canvasWidth, height: canvasHeight }).line(
-	  c
-	    points[i - 1][0], points[i - 1][1],
-		points[i][0], points[i][1]
+	    c,
+	    new_points[i - 1][0], new_points[i - 1][1],
+		new_points[i][0], new_points[i][1]
 	  )
     }
-  },
-
-  polyFill (points, c) {
-    if (!points.length) {
-      return
-    }
-    ctx.fillStyle = colors.one(c)
-    ctx.beginPath()
-    ctx.moveTo(Math.floor(points[0][0]), Math.floor(points[0][1]))
-    for (let i = 0; i < points.length; i++) {
-      ctx.lineTo(Math.floor(points[i][0]), Math.floor(points[i][1]))
-    }
-    ctx.closePath()
-    ctx.fill()
   },
 
   circStroke (x, y, r, c) {

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -100,7 +100,7 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     for (let i = 1; i < points.length; i++) {
       line({
         x1: Math.round(new_points[i - 1][0]), y1: Math.round(new_points[i - 1][1]),
-        x2: Marh.round(new_points[i][0]), y2: Math.round(new_points[i][1]),
+        x2: Math.round(new_points[i][0]), y2: Math.round(new_points[i][1]),
         ctx,
         color: c
       })

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -52,9 +52,9 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     }
     ctx.strokeStyle = colors.one(c)
     ctx.beginPath()
-    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]))
+    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]) - 1)
     for (let i = 0; i < points.length; i++) {
-      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]))
+      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]) - 1)
     }
     ctx.closePath()
     ctx.stroke()
@@ -66,9 +66,9 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     }
     ctx.fillStyle = colors.one(c)
     ctx.beginPath()
-    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]))
+    ctx.moveTo(Math.floor(points[0][0]), Math.floor(points[0][1]))
     for (let i = 0; i < points.length; i++) {
-      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]))
+      ctx.lineTo(Math.floor(points[i][0]), Math.floor(points[i][1]))
     }
     ctx.closePath()
     ctx.fill()

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -46,6 +46,35 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     ctx.fillRect(Math.floor(x), Math.floor(y), Math.floor(w), Math.floor(h))
   },
 
+  polyStroke (points, c, w) {
+    if (!points.length) {
+      return
+    }
+    ctx.strokeStyle = colors.one(c)
+    ctx.lineWidth = w
+    ctx.beginPath()
+    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]))
+    for (let i = 0; i < points.length; i++) {
+      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]))
+    }
+    ctx.closePath()
+    ctx.stroke()
+  },
+
+  polyFill (points, c) {
+    if (!points.length) {
+      return
+    }
+    ctx.fillStyle = colors.one(c)
+    ctx.beginPath()
+    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]))
+    for (let i = 0; i < points.length; i++) {
+      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]))
+    }
+    ctx.closePath()
+    ctx.fill()
+  },
+
   circStroke (x, y, r, c) {
     circle({
       cx: Math.floor(x),

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -26,6 +26,49 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     ctx.stroke()
     ctx.setLineDash([])
   },
+  
+  line (x1, y1, x2, y2, c) {
+    ctx.fillStyle = colors.one(c)
+    let steep = false
+    if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {
+      [x1, y1] = [y1, x1]
+      [x2, y2] = [y2, x2]
+      steep = true
+    }
+    if (x1 > x2) {
+      [x1, x2] = [x2, x1]
+      [y1, y2] = [y2, y1]
+    }
+    let dx = x2 - x1
+    let dy = y2 - y1
+    let derror = Math.abs(dy) * 2
+    let error = 0
+    let y = y1
+    for (let x = x1; x <= x2; x++) {
+      if (steep) {
+        ctx.fillRect(
+          Math.round(x) + 0.5,
+          Math.round(y) + 0.5,
+          1, 1
+        )
+      } else {
+        ctx.fillRect(
+          Math.round(y) + 0.5,
+          Math.round(x) + 0.5,
+          1, 1
+        )
+      }
+      error += derror
+      if (error > dx) {
+        if (y2 > y1) {
+            y++
+        } else {
+            y--
+        }
+        error -= dx * 2
+      }
+    }
+  }
 
   print (x, y, letters, c) {
     print({ x, y, letters, c, ctx })

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -72,8 +72,8 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         break
       case 2:
         c = args[1]
-        x_rot = Math.cos(args[0])
-        y_rot = Math.sin(args[0])
+        x_rot = Math.cos(args[0] / 90 * Math.PI)
+        y_rot = Math.sin(args[0] / 90 * Math.PI)
         let xs = points.map(p => p[0])
         let ys = points.map(p => p[1])
         mid_x = (Math.min.apply(Math, xs) + Math.max.apply(Math, xs)) / 2
@@ -87,8 +87,8 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         throw "`polyStroke` found 3 arguments instead of 2, 3, or 5."
       default:
         c = args[3]
-        x_rot = Math.cos(args[0])
-        y_rot = Math.sin(args[0])
+        x_rot = Math.cos(args[0] / 90 * Math.PI)
+        y_rot = Math.sin(args[0] / 90 * Math.PI)
         mid_x = args[1]
         mid_y = args[2]
         new_points = points.map(p => [

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -46,12 +46,11 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     ctx.fillRect(Math.floor(x), Math.floor(y), Math.floor(w), Math.floor(h))
   },
 
-  polyStroke (points, c, w) {
+  polyStroke (points, c) {
     if (!points.length) {
       return
     }
     ctx.strokeStyle = colors.one(c)
-    ctx.lineWidth = w
     ctx.beginPath()
     ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]))
     for (let i = 0; i < points.length; i++) {

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -60,7 +60,11 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     if (!points.length) {
       return
     }
-    let c, new_points
+    let
+      c,
+      new_points,
+      x_rot, y_rot,
+      mid_x, mid_y
     switch (args.length) {
       case 1:
         c = args[0]
@@ -68,12 +72,12 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         break
       case 2:
         c = args[1]
-        let x_rot = Math.cos(args[0])
-        let y_rot = Math.sin(args[0])
+        x_rot = Math.cos(args[0])
+        y_rot = Math.sin(args[0])
         let xs = points.map(p => p[0])
         let ys = points.map(p => p[1])
-        let mid_x = (Math.min.apply(Math, xs) + Math.max.apply(Math, xs)) / 2
-        let mid_y = (Math.min.apply(Math, ys) + Math.max.apply(Math, ys)) / 2
+        mid_x = (Math.min.apply(Math, xs) + Math.max.apply(Math, xs)) / 2
+        mid_y = (Math.min.apply(Math, ys) + Math.max.apply(Math, ys)) / 2
         new_points = points.map(p => [
           ((p[0] - mid_x) * x_rot - (p[1] - mid_y) * y_rot) + mid_x,
           ((p[0] - mid_x) * y_rot + (p[1] - mid_y) * x_rot) + mid_y
@@ -83,10 +87,10 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         throw "`polyStroke` found 3 arguments instead of 2, 3, or 5."
       default:
         c = args[3]
-        let x_rot = Math.cos(args[0])
-        let y_rot = Math.sin(args[0])
-        let mid_x = args[1]
-        let mid_y = args[2]
+        x_rot = Math.cos(args[0])
+        y_rot = Math.sin(args[0])
+        mid_x = args[1]
+        mid_y = args[2]
         new_points = points.map(p => [
           ((p[0] - mid_x) * x_rot - (p[1] - mid_y) * y_rot) + mid_x,
           ((p[0] - mid_x) * y_rot + (p[1] - mid_y) * x_rot) + mid_y

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -1,5 +1,6 @@
 import colors from '../colors.js'
 import circle from './circle.js'
+import line from './line.js'
 import print from './print.js'
 
 const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
@@ -28,47 +29,13 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
   },
   
   line (x1, y1, x2, y2, c) {
-    ctx.fillStyle = colors.one(c)
-    let steep = false
-    if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {
-      [x1, y1] = [y1, x1];
-      [x2, y2] = [y2, x2];
-      steep = true
-    }
-    if (x1 > x2) {
-      [x1, x2] = [x2, x1];
-      [y1, y2] = [y2, y1];
-    }
-    let dx = x2 - x1
-    let dy = y2 - y1
-    let derror = Math.abs(dy) * 2
-    let error = 0
-    let y = y1
-    for (let x = x1; x <= x2; x++) {
-      if (steep) {
-        ctx.fillRect(
-          Math.round(y) + 0.5,
-          Math.round(x) + 0.5,
-          1, 1
-        )
-      } else {
-        ctx.fillRect(
-          Math.round(x) + 0.5,
-          Math.round(y) + 0.5,
-          1, 1
-        )
-      }
-      error += derror
-      if (error > dx) {
-        if (y2 > y1) {
-            y++
-        } else {
-            y--
-        }
-        error -= dx * 2
-      }
-    }
-  }
+    line({
+	  Math.floor(x1), Math.floor(y1),
+	  Math.floor(x2), Math.floor(y2),
+	  ctx,
+	  color: colors.one(c)
+	})
+  },
 
   print (x, y, letters, c) {
     print({ x, y, letters, c, ctx })
@@ -127,11 +94,12 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
         break
     }
     for (let i = 1; i < points.length; i++) {
-      canvasAPI({ ctx, width: canvasWidth, height: canvasHeight }).line(
-        c,
-        new_points[i - 1][0], new_points[i - 1][1],
-        new_points[i][0], new_points[i][1]
-      )
+      line({
+        x1: new_points[i - 1][0], y1: new_points[i - 1][1],
+        x2: new_points[i][0], y2: new_points[i][1],
+        ctx,
+        color: c
+      })
     }
   },
 

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -99,15 +99,15 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     }
     for (let i = 1; i < points.length; i++) {
       line({
-        x1: new_points[i - 1][0], y1: new_points[i - 1][1],
-        x2: new_points[i][0], y2: new_points[i][1],
+        x1: Math.round(new_points[i - 1][0]), y1: Math.round(new_points[i - 1][1]),
+        x2: Marh.round(new_points[i][0]), y2: Math.round(new_points[i][1]),
         ctx,
         color: c
       })
     }
     line({
-      x1: new_points[new_points.length - 1][0], y1: new_points[new_points.length - 1][1],
-      x2: new_points[0][0], y2: new_points[0][1],
+      x1: Math.round(new_points[new_points.length - 1][0]), y1: Math.round(new_points[new_points.length - 1][1]),
+      x2: Math.round(new_points[0][0]), y2: Math.round(new_points[0][1]),
       ctx,
       color: c
     })

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -93,24 +93,45 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     if (!points.length) {
       return
     }
-	let c = args[args.length - 1]
-	let new_points
-	switch(args.length) {
-	  case 1:
-	    new_points = points.map(p => [...p])
-		break;
-	  case 2:
-	    let xs = points.map(p => p[0])
-		let ys = points.map(p => p[1])
-		let min_x = 
-		new_points = points.map(p => [p[0]])
-	}
+    let c, new_points
+    switch (args.length) {
+      case 1:
+        c = args[0]
+        new_points = points.map(p => [...p])
+        break
+      case 2:
+        c = args[1]
+        let x_rot = Math.cos(args[0])
+        let y_rot = Math.sin(args[0])
+        let xs = points.map(p => p[0])
+        let ys = points.map(p => p[1])
+        let mid_x = (Math.min.apply(Math, xs) + Math.max.apply(Math, xs)) / 2
+        let mid_y = (Math.min.apply(Math, ys) + Math.max.apply(Math, ys)) / 2
+        new_points = points.map(p => [
+          ((p[0] - mid_x) * x_rot - (p[1] - mid_y) * y_rot) + mid_x,
+          ((p[0] - mid_x) * y_rot + (p[1] - mid_y) * x_rot) + mid_y
+        ])
+        break
+      case 3:
+        throw "`polyStroke` found 3 arguments instead of 2, 3, or 5."
+      default:
+        c = args[3]
+        let x_rot = Math.cos(args[0])
+        let y_rot = Math.sin(args[0])
+        let mid_x = args[1]
+        let mid_y = args[2]
+        new_points = points.map(p => [
+          ((p[0] - mid_x) * x_rot - (p[1] - mid_y) * y_rot) + mid_x,
+          ((p[0] - mid_x) * y_rot + (p[1] - mid_y) * x_rot) + mid_y
+        ])
+        break
+    }
     for (let i = 1; i < points.length; i++) {
-	  canvasAPI({ ctx, width: canvasWidth, height: canvasHeight }).line(
-	    c,
-	    new_points[i - 1][0], new_points[i - 1][1],
-		new_points[i][0], new_points[i][1]
-	  )
+      canvasAPI({ ctx, width: canvasWidth, height: canvasHeight }).line(
+        c,
+        new_points[i - 1][0], new_points[i - 1][1],
+        new_points[i][0], new_points[i][1]
+      )
     }
   },
 

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -31,13 +31,13 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     ctx.fillStyle = colors.one(c)
     let steep = false
     if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {
-      [x1, y1] = [y1, x1]
-      [x2, y2] = [y2, x2]
+      [x1, y1] = [y1, x1];
+      [x2, y2] = [y2, x2];
       steep = true
     }
     if (x1 > x2) {
-      [x1, x2] = [x2, x1]
-      [y1, y2] = [y2, y1]
+      [x1, x2] = [x2, x1];
+      [y1, y2] = [y2, y1];
     }
     let dx = x2 - x1
     let dy = y2 - y1
@@ -47,14 +47,14 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     for (let x = x1; x <= x2; x++) {
       if (steep) {
         ctx.fillRect(
-          Math.round(x) + 0.5,
           Math.round(y) + 0.5,
+          Math.round(x) + 0.5,
           1, 1
         )
       } else {
         ctx.fillRect(
-          Math.round(y) + 0.5,
           Math.round(x) + 0.5,
+          Math.round(y) + 0.5,
           1, 1
         )
       }

--- a/src/utils/canvasAPI/index.js
+++ b/src/utils/canvasAPI/index.js
@@ -93,14 +93,13 @@ const canvasAPI = ({ ctx, width: canvasWidth, height: canvasHeight }) => ({
     if (!points.length) {
       return
     }
-    ctx.strokeStyle = colors.one(c)
-    ctx.beginPath()
-    ctx.moveTo(Math.floor(points[0][0]) + 0.5, Math.floor(points[0][1]) - 1)
-    for (let i = 0; i < points.length; i++) {
-      ctx.lineTo(Math.floor(points[i][0]) + 0.5, Math.floor(points[i][1]) - 1)
+    for (let i = 1; i < points.length; i++) {
+	  canvasAPI({ ctx, width: canvasWidth, height: canvasHeight }).line(
+	  c
+	    points[i - 1][0], points[i - 1][1],
+		points[i][0], points[i][1]
+	  )
     }
-    ctx.closePath()
-    ctx.stroke()
   },
 
   polyFill (points, c) {

--- a/src/utils/canvasAPI/line.js
+++ b/src/utils/canvasAPI/line.js
@@ -1,0 +1,6 @@
+const line ({ x1, y1, x2, y2, ctx, color }) {  ctx.fillStyle = color  let steep = false
+    if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {    [x1, y1] = [y1, x1];    [x2, y2] = [y2, x2];    steep = true  }  if (x1 > x2) {    [x1, x2] = [x2, x1];    [y1, y2] = [y2, y1];  }
+    let dx = x2 - x1  let dy = y2 - y1  let derror = Math.abs(dy) * 2  let error = 0  let y = y1
+    for (let x = x1; x <= x2; x++) {    if (steep) {      ctx.fillRect(y, x, 1, 1)    } else {      ctx.fillRect(x, y, 1, 1)    }    error += derror    if (error > dx) {      if (y2 > y1) {          y++      } else {          y--      }      error -= dx * 2    }  }}
+
+export default line

--- a/src/utils/canvasAPI/line.js
+++ b/src/utils/canvasAPI/line.js
@@ -1,4 +1,4 @@
-const line ({ x1, y1, x2, y2, ctx, color }) {
+const line ({ x1, y1, x2, y2, ctx, color }) => {
   ctx.fillStyle = color
   let steep = false
   

--- a/src/utils/canvasAPI/line.js
+++ b/src/utils/canvasAPI/line.js
@@ -1,4 +1,4 @@
-const line ({ x1, y1, x2, y2, ctx, color }) => {
+const line = ({ x1, y1, x2, y2, ctx, color }) => {
   ctx.fillStyle = color
   let steep = false
   

--- a/src/utils/canvasAPI/line.js
+++ b/src/utils/canvasAPI/line.js
@@ -1,6 +1,39 @@
-const line ({ x1, y1, x2, y2, ctx, color }) {  ctx.fillStyle = color  let steep = false
-    if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {    [x1, y1] = [y1, x1];    [x2, y2] = [y2, x2];    steep = true  }  if (x1 > x2) {    [x1, x2] = [x2, x1];    [y1, y2] = [y2, y1];  }
-    let dx = x2 - x1  let dy = y2 - y1  let derror = Math.abs(dy) * 2  let error = 0  let y = y1
-    for (let x = x1; x <= x2; x++) {    if (steep) {      ctx.fillRect(y, x, 1, 1)    } else {      ctx.fillRect(x, y, 1, 1)    }    error += derror    if (error > dx) {      if (y2 > y1) {          y++      } else {          y--      }      error -= dx * 2    }  }}
+const line ({ x1, y1, x2, y2, ctx, color }) {
+  ctx.fillStyle = color
+  let steep = false
+  
+  if (Math.abs(x1 - x2) < Math.abs(y1 - y2)) {
+    [x1, y1] = [y1, x1];
+    [x2, y2] = [y2, x2];
+    steep = true
+  }
+  if (x1 > x2) {
+    [x1, x2] = [x2, x1];
+    [y1, y2] = [y2, y1];
+  }
+  
+  let dx = x2 - x1
+  let dy = y2 - y1
+  let derror = Math.abs(dy) * 2
+  let error = 0
+  let y = y1
+  
+  for (let x = x1; x <= x2; x++) {
+    if (steep) {
+      ctx.fillRect(y, x, 1, 1)
+    } else {
+      ctx.fillRect(x, y, 1, 1)
+    }
+    error += derror
+    if (error > dx) {
+      if (y2 > y1) {
+          y++
+      } else {
+          y--
+      }
+      error -= dx * 2
+    }
+  }
+}
 
 export default line


### PR DESCRIPTION
`polyStroke` takes `points` and `c` to draw the outline of a polygon on the screen with the `points` and `c` as colour.
`polyFill` takes `points` and `c` to draw a polygon on the screen with the `points` and `c` as colour.
`points` is an array of `[x, y]` form points. _(Could be in `{x: x, y: y}` form.)_