### PR TITLE
Simplify getting started

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+ports:
+- port: 3000
+  onOpen: open-preview
+- port: 3001
+  onOpen: ignore
+tasks:
+- init: yarn
+  command: yarn iframe-start
+- command: >
+    while ! timeout 1 bash -c "echo >/dev/tcp/localhost/3001"; do sleep 10; done &&
+    yarn start
+  openMode: split-right

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # SCRIPT-8
 A JavaScript-based ([React](https://reactjs.org/) + [Redux](https://redux.js.org/)) fantasy computer for making, sharing, and playing tiny retro-looking games.
 
-## Setup for local development
+## Setup for development
+
+You can edit the code base in Gitpod, a free online dev environment for GitHub.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/script-8/script-8.github.io)
+
+## Local development
 
 ### 0 - Clone or download this repository
 


### PR DESCRIPTION
Cool project! 🎉 
This PR just adds a config and button to allow people playing around immediately. It uses Gitpod, a free online dev environment for Gitpod we have been working on for the path months. It allows for easier contributing to the project and generally playing around with script-8.

I configured it so that it automatically opens two terminals with
 - `yarn iframe-start``
 - `yarn start`

similar as you described for the local setup.

<img width="1521" alt="screenshot 2019-01-27 at 08 51 23" src="https://user-images.githubusercontent.com/372735/51798287-c2879f80-2210-11e9-9cc7-f9db2e54d0d4.png">

Try it out:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/eb14e570-9663-4545-8fd1-ec06771ce99f)


