### PR TITLE
Added Prettier support with Alt-P.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lz-string": "^1.4.4",
     "npm-run-all": "^4.1.2",
     "omit-empty": "^0.4.1",
+    "prettier": "^1.16.4",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/components/CodeEditor.js
+++ b/src/components/CodeEditor.js
@@ -4,6 +4,8 @@ import includes from 'lodash/includes'
 import setupLinter from '../utils/setupLinter.js'
 import commands from '../utils/commands.js'
 import blank from '../iframe/src/blank.js'
+import prettierParser from 'prettier/parser-babylon'
+import prettier from 'prettier/standalone'
 
 const { platform } = window.navigator
 
@@ -53,6 +55,29 @@ class CodeEditor extends Component {
         }
       }
     })
+
+    const prettierOpts = cursorOffset => ({
+      parser: "babel",
+      plugins: {
+        babel: prettierParser
+      },
+      cursorOffset
+    });
+
+    this.codeMirror.addKeyMap({
+      "Alt-P": () => {
+        const oldCode = this.codeMirror.getValue()
+        const index = this.codeMirror.indexFromPos(this.codeMirror.getCursor())
+        const {formatted, cursorOffset} = prettier.formatWithCursor(
+          oldCode,
+          prettierOpts(index)
+        )
+        this.setContents(formatted)
+
+        const newCursor = this.codeMirror.posFromIndex(cursorOffset)
+        this.codeMirror.setCursor(newCursor)
+      }
+    });
 
     // Add this eventlistener to window.
     window.addEventListener('keyup', this.hideSlider)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5884,6 +5884,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"


### PR DESCRIPTION
Closes #138.

Preserves the cursor position. Maybe it'd be nice to try to scroll to
the same relative position in the code, if prettier adds/removes too
many lines? What if the user wants to change options for Prettier?