### PR TITLE
Add key pressed and released properties on input

### DIFF
--- a/src/iframe/src/getUserInput.js
+++ b/src/iframe/src/getUserInput.js
@@ -1,7 +1,9 @@
+let previousUserInput = {}
+
 const getUserInput = keys => {
   const { buttons } = window.navigator.getGamepads()[0] || {}
 
-  return {
+  let newUserInput = {
     __mousedown: keys.has('mousedown'),
     up: keys.has('ArrowUp') || (buttons && buttons[12].pressed),
     right: keys.has('ArrowRight') || (buttons && buttons[15].pressed),
@@ -12,6 +14,18 @@ const getUserInput = keys => {
     start: keys.has('Enter') || (buttons && buttons[9].pressed),
     select: keys.has(' ') || (buttons && buttons[8].pressed)
   }
+
+  for (var key of Object.keys(newUserInput)) {
+    let keyPressed = !previousUserInput[key] && newUserInput[key]
+    newUserInput[key + "Pressed"] = keyPressed
+
+    let keyReleased = previousUserInput[key] && !newUserInput[key]
+    newUserInput[key + "Released"] = keyReleased
+  }
+
+  previousUserInput = newUserInput
+
+  return previousUserInput
 }
 
 export default getUserInput

--- a/src/iframe/src/getUserInput.js
+++ b/src/iframe/src/getUserInput.js
@@ -15,7 +15,7 @@ const getUserInput = keys => {
     select: keys.has(' ') || (buttons && buttons[8].pressed)
   }
 
-  for (var key of Object.keys(newUserInput)) {
+  for (const key of Object.keys(newUserInput)) {
     let keyPressed = !previousUserInput[key] && newUserInput[key]
     newUserInput[key + "Pressed"] = keyPressed
 

--- a/src/iframe/src/getUserInput.js
+++ b/src/iframe/src/getUserInput.js
@@ -25,7 +25,7 @@ const getUserInput = keys => {
 
   previousUserInput = newUserInput
 
-  return previousUserInput
+  return newUserInput
 }
 
 export default getUserInput

--- a/src/iframe/src/getUserInput.js
+++ b/src/iframe/src/getUserInput.js
@@ -16,6 +16,8 @@ const getUserInput = keys => {
   }
 
   for (const key of Object.keys(newUserInput)) {
+    if (key.startsWith("__")) continue;
+
     let keyPressed = !previousUserInput[key] && newUserInput[key]
     newUserInput[key + "Pressed"] = keyPressed
 

--- a/src/utils/apiDocs.yaml
+++ b/src/utils/apiDocs.yaml
@@ -16,7 +16,7 @@
   dl:
   -
     - ''
-    - "The `update` function receives `input` as its second parameter. It's an object of booleans, each representing whether a button is pressed or not: up, right, down, left, a, b, start, select. On keyboards, the last two represent Enter and Space, respectively. For example, if you're holding right and up, `input` will be { right: true, up: true }."
+    - "The `update` function receives `input` as its second parameter. It's an object of booleans, each representing whether a button is currently held down or not: up, right, down, left, a, b, start, select. On keyboards, the last two represent Enter and Space, respectively. For example, if you're holding right and up, `input` will be { right: true, up: true }. This object also contains {key}Prssed and {key}Released properties indicating if the key was first pressed down on the current frame and if the key was first released on the current frame respectively."
 - title: Draw
   note: non-integers are rounded down
   dl:


### PR DESCRIPTION
This adds tracking of the previous input state and adds key pressed and released properties to the input object.

This currently also adds __mouseDownPressed and __mouseDownReleased properties. I left it as is because its more elegant, the properties aren't documented, and they are potentially useful, but I could add an if statement to modify the variable name if you would like.

I'm not super happy with the documentation change either... I think the paragraph is getting long enough that it might be useful to break it up into multiple lines, but I didn't spend the time to see how the documentation ui was created. I can do that work if you would like though.
