### PR TITLE
Changes code size to use the acorn token count instead of zipped character count

### DIFF
--- a/src/containers/Output.js
+++ b/src/containers/Output.js
@@ -40,6 +40,14 @@ const mapDispatchToProps = dispatch => ({
   finishBoot: () => dispatch(actions.finishBoot())
 })
 
+const getTokenCount = src => {
+  try {
+    return numberWithCommas([...tokenizer(src)].length)
+  } catch (error) {
+    return "ERROR"
+  }
+}
+
 class Output extends Component {
   constructor(props) {
     super(props)
@@ -172,20 +180,6 @@ class Output extends Component {
   getSize() {
     const { game, songs, chains, phrases, sprites, map } = this.props
 
-    function getTokenCount(src) {
-      try {
-        return numberWithCommas([...tokenizer(src)].length)
-      } catch (error) {
-        return "ERROR"
-      }
-    }
-
-    function renderCodeCount(name, code) {
-      return <li key={name}>
-        {name}: {getTokenCount(code)}
-      </li>
-    }
-
     const code = assembleOrderedGame(game)
     const art = JSON.stringify({ sprites, map })
     const music = JSON.stringify({ phrases, chains, songs })
@@ -200,7 +194,11 @@ class Output extends Component {
 
     return (
       <ul>
-        {_.toPairs(assets).map(pair => renderCodeCount(...pair))}
+        {_.toPairs(assets).map(pair => ((name, code) => (
+          <li key={name}>
+            {name}: {getTokenCount(code)}
+          </li>
+        ))(...pair))}
       </ul>
     )
   }

--- a/src/containers/Output.js
+++ b/src/containers/Output.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import classNames from 'classnames'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import lz from 'lz-string'
+import { tokenizer } from "acorn";
 import actions from '../actions/actions.js'
 import bios from '../utils/bios.js'
 import screenTypes from '../utils/screenTypes.js'
@@ -10,9 +10,6 @@ import isBlank from '../utils/isBlank.js'
 import { getLintErrors } from '../utils/setupLinter.js'
 import { numberWithCommas } from '../utils/string.js'
 import { assembleOrderedGame } from '../reducers/game.js'
-
-const sum = array =>
-  array.reduce((accumulator, currentValue) => accumulator + currentValue, 0)
 
 const mapStateToProps = ({
   screen,
@@ -175,32 +172,35 @@ class Output extends Component {
   getSize() {
     const { game, songs, chains, phrases, sprites, map } = this.props
 
-    const gameText = assembleOrderedGame(game)
+    function getTokenCount(src) {
+      try {
+        return numberWithCommas([...tokenizer(src)].length)
+      } catch (error) {
+        return "ERROR"
+      }
+    }
 
-    const gameTextLz = lz.compress(gameText)
+    function renderCodeCount(name, code) {
+      return <li key={name}>
+        {name}: {getTokenCount(code)}
+      </li>
+    }
+
+    const code = assembleOrderedGame(game)
     const art = JSON.stringify({ sprites, map })
-    const artLz = lz.compress(art)
     const music = JSON.stringify({ phrases, chains, songs })
-    const musicLz = lz.compress(music)
+    const total = code + art + music
 
-    const sizes = [
-      ['code', gameText, gameTextLz],
-      ['art', art, artLz],
-      ['music', music, musicLz]
-    ]
+    const assets = {
+      code,
+      art,
+      music,
+      total
+    };
 
     return (
       <ul>
-        {sizes.map((d, i) => (
-          <li key={i}>
-            {d[0]}: {numberWithCommas(d[1].length)}/
-            {numberWithCommas(d[2].length)}
-          </li>
-        ))}
-        <li>
-          total: {numberWithCommas(sum(sizes.map(d => d[1].length)))}/
-          {numberWithCommas(sum(sizes.map(d => d[2].length)))}
-        </li>
+        {_.toPairs(assets).map(pair => renderCodeCount(...pair))}
       </ul>
     )
   }


### PR DESCRIPTION
When acorn can't parse a string, it throws an exception. So instead of doing anything fancy, I put the counter in a try catch which will return "ERROR" if parse fails.

I changed things around a bit while trying to figure out why things weren't working (I'm somewhat new to react) so if you dislike the style I can change it to be a bit more like it was.

I also removed the lz minified count because I figured it was superfluous now. If you would like the total character count with the token count where the minified one was instead I can do that as well, just let me know.