### PR TITLE
mouse position display

### DIFF
--- a/src/iframe/src/Iframe.js
+++ b/src/iframe/src/Iframe.js
@@ -163,7 +163,8 @@ class Iframe extends Component {
       isPaused: true,
       alteredStates: [],
       run: true,
-      sound: true
+      sound: true,
+      mousePosition: { x: 0, y: 0 }
     }
   }
 
@@ -331,6 +332,14 @@ class Iframe extends Component {
     this.mouseupHandler = () => {
       this.keys.delete('mousedown')
     }
+    this.mousemoveHandler = ({ target, clientX, clientY }) => {
+      if (target.classList.contains("master")) {
+        const canvasClientRect = target.getBoundingClientRect();
+        let x = Math.floor((clientX - canvasClientRect.left) * target.width / canvasClientRect.width)
+        let y = Math.floor((clientY - canvasClientRect.top) * target.height / canvasClientRect.height)
+        this.setState({ mousePosition: { x, y } })
+      }
+    }
     this.keydownHandler = ({ key }) => {
       this.keys.add(key)
     }
@@ -342,6 +351,7 @@ class Iframe extends Component {
     document.addEventListener('mousedown', this.mousedownHandler)
     document.addEventListener('touchend', this.mouseupHandler)
     document.addEventListener('mouseup', this.mouseupHandler)
+    document.addEventListener('mousemove', this.mousemoveHandler)
     document.addEventListener('keydown', this.keydownHandler)
     document.addEventListener('keyup', this.keyupHandler)
 
@@ -412,6 +422,7 @@ class Iframe extends Component {
     document.removeEventListener('mousedown', this.mousedownHandler)
     document.removeEventListener('touchend', this.mouseupHandler)
     document.removeEventListener('mouseup', this.mouseupHandler)
+    document.removeEventListener('mousemove', this.mousemoveHandler)
     document.removeEventListener('keydown', this.keydownHandler)
     document.removeEventListener('keyup', this.keyupHandler)
   }
@@ -933,12 +944,16 @@ class Iframe extends Component {
               restart
             </button>
 
-            <div
-              className={classNames('fps', {
-                hide: isPaused
-              })}
+            <div className={classNames('stat-values', {
+              hide: isPaused
+            })}
             >
-              fps (avg): <span>{fps}</span>
+              <div className={classNames('stat')}>
+                mouse: (<span>{this.state.mousePosition.x}</span>, <span>{this.state.mousePosition.y}</span>)
+              </div>
+              <div className={classNames('stat')}>
+                fps (avg): <span>{fps}</span>
+              </div>
             </div>
           </div>
           <div

--- a/src/iframe/src/css/Iframe.css
+++ b/src/iframe/src/css/Iframe.css
@@ -60,7 +60,7 @@
 }
 .VT323,
 .button,
-.stats .fps {
+.stats .stat-values .stat {
   font-family: 'VT323', monospace;
 }
 html {
@@ -230,8 +230,10 @@ ul li button.active canvas {
 .stats button {
   padding-right: 1rem;
 }
-.stats .fps {
+.stats .stat-values {
   margin-left: auto;
+}
+.stats .stat-values .stat {
   color: #0f2a3f;
   font-size: 1.5rem;
 }

--- a/src/iframe/src/css/Iframe.styl
+++ b/src/iframe/src/css/Iframe.styl
@@ -149,11 +149,13 @@ ul
   button
     padding-right 1rem
 
-  .fps
+  .stat-values
     margin-left auto
-    color $palette-6
-    font-size $font-large
-    @extend .VT323
+
+    .stat
+      color $palette-6
+      font-size $font-large
+      @extend .VT323
 
 .hide
   display none


### PR DESCRIPTION
Adds the mouse pixel position to the stats display for debugging purposes.

![image](https://user-images.githubusercontent.com/3323631/53307878-89633f00-3851-11e9-996d-2cb3880fd48c.png)

This is useful for locating exactly where you want a sprite to go on the screen. Instead of fiddling with the values, you can place your mouse where you want it and use the reported values.
