### PR TITLE
fix getPixel to be in camera coordinates not canvas coordinates

### DIFF
--- a/src/iframe/src/canvasAPI/index.js
+++ b/src/iframe/src/canvasAPI/index.js
@@ -189,8 +189,8 @@ const canvasAPI = ({
 
     getPixel(x, y) {
       return getPixel({
-        x: Math.floor(x),
-        y: Math.floor(y),
+        x: Math.floor(x - _cameraX),
+        y: Math.floor(y - _cameraY),
         ctx
       })
     },


### PR DESCRIPTION
Fixes part of https://github.com/script-8/script-8.github.io/issues/222 so that setPixel(x, y, c); getPixel(x, y) will always return c.