### PR TITLE
floor passed in coordinates to camera, or drawn graphics works incorrectly

### DIFF
--- a/src/iframe/src/canvasAPI/index.js
+++ b/src/iframe/src/canvasAPI/index.js
@@ -85,8 +85,8 @@ const canvasAPI = ({
     },
 
     camera(x = 0, y = 0) {
-      _cameraX = x
-      _cameraY = y
+      _cameraX = Math.floor(x)
+      _cameraY = Math.floor(y)
       ctx.setTransform(1, 0, 0, 1, 0, 0)
       ctx.translate(-x, -y)
     },


### PR DESCRIPTION
Solves the second half of https://github.com/script-8/script-8.github.io/issues/222. Turns out fractional transforms cause graphics to act strangely. Calling Math.floor on transform coordinates cleans things up and makes camera more reliable.