### PR TITLE
Support browsers that don't support Gamepads

### DIFF
--- a/src/iframe/src/getUserInput.js
+++ b/src/iframe/src/getUserInput.js
@@ -1,7 +1,9 @@
 let previousUserInput = {}
 
 const getUserInput = keys => {
-  const { buttons } = window.navigator.getGamepads()[0] || {}
+  const { buttons } = window.navigator.getGamepads
+    ? window.navigator.getGamepads()[0] || {}
+    : {}
 
   let newUserInput = {
     __mousedown: keys.has('mousedown'),


### PR DESCRIPTION
* Currently Gnome Web (aka Epiphany)

In Epiphany (and I assume WebkitGtk webviews, Script-8 runs fine but fails with error because `window.navigator.getGamepads` was undefined.