### PR TITLE
Actually fix camera bug

### DIFF
--- a/src/iframe/src/canvasAPI/index.js
+++ b/src/iframe/src/canvasAPI/index.js
@@ -92,7 +92,7 @@ const canvasAPI = ({
       _cameraX = Math.floor(x)
       _cameraY = Math.floor(y)
       ctx.setTransform(1, 0, 0, 1, 0, 0)
-      ctx.translate(-x, -y)
+      ctx.translate(-_cameraX, -_cameraY)
     },
 
     rectFill(x, y, w, h, c = 0) {


### PR DESCRIPTION
Previous PR updated _cameraX and _cameraY to use Math.floor, but forgo to update the actual call to context2D.translate. This fixes that.

My bad :(