### PR TITLE
fix print bug

### DIFF
--- a/src/iframe/src/frameBufferCanvasAPI/index.js
+++ b/src/iframe/src/frameBufferCanvasAPI/index.js
@@ -101,17 +101,12 @@ const canvasAPI = ({
   }
 
   const print = (x, y, letters, c = 0) => {
-    if (x - _cameraX < 0 || x - _cameraX > canvasWidth) return
-    if (y - _cameraY < 0 || y - _cameraY > canvasHeight) return
-
     drawText({
       x,
       y,
       letters,
       c,
-      setPixel,
-      cameraX: _cameraX,
-      cameraY: _cameraY
+      setPixel
     })
   }
 

--- a/src/iframe/src/frameBufferCanvasAPI/print.js
+++ b/src/iframe/src/frameBufferCanvasAPI/print.js
@@ -1,6 +1,6 @@
 import alphabet from './alphabet.js'
 
-const drawText = ({ x, y, letters, c, setPixel, cameraX, cameraY }) => {
+const drawText = ({ x, y, letters, c, setPixel }) => {
   let currentX = Math.floor(x)
   let currentY = Math.floor(y)
 


### PR DESCRIPTION
premature optimization

I had a check that would prevent doing the print calculation if the coordinates passed were off screen. Obviously this isn't ok because text moves horizontally past the starting position. So I removed the checks.