### PR TITLE
Switch Map to use Frame Buffer Api

### DIFF
--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -13,7 +13,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 class Map extends Component {
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.handleOnMouseDown = this.handleOnMouseDown.bind(this)
     this.handleOnMouseEnter = this.handleOnMouseEnter.bind(this)
@@ -22,11 +22,11 @@ class Map extends Component {
     this.handleSpriteClick = this.handleSpriteClick.bind(this)
     this.handleRoomClick = this.handleRoomClick.bind(this)
 
-    this.spritePixelData = pixelData({ width: 128, height: 64 });
+    this.spritePixelData = pixelData({ width: 128, height: 64 })
     this.drawSprite = this.drawSprite.bind(this)
-    this.roomPixelData = pixelData({ width: 128, height: 128 });
+    this.roomPixelData = pixelData({ width: 128, height: 128 })
     this.drawRoom = this.drawRoom.bind(this)
-    this.mapPixelData = pixelData({ width: 128 * 8, height: 128 * 4});
+    this.mapPixelData = pixelData({ width: 128 * 8, height: 128 * 4 })
     this.drawMap = this.drawMap.bind(this)
     this.getCurrentRoom = this.getCurrentRoom.bind(this)
     this.setMode = this.setMode.bind(this)
@@ -39,13 +39,13 @@ class Map extends Component {
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.drawSprites()
     this.drawRoom()
     this.drawMap()
   }
 
-  drawSprites () {
+  drawSprites() {
     const { sprites } = this.props
 
     this.spriteCanvasAPI = canvasAPI({
@@ -61,10 +61,12 @@ class Map extends Component {
       const col = key % 16
       this.spriteCanvasAPI.sprite(col * 8, row * 8, key)
     })
-    this.spritePixelData.writePixelDataToCanvas(this._spriteCanvas.getContext('2d'))
+    this.spritePixelData.writePixelDataToCanvas(
+      this._spriteCanvas.getContext('2d')
+    )
   }
 
-  drawRoom () {
+  drawRoom() {
     const before = Date.now()
 
     const { sprites, map } = this.props
@@ -93,7 +95,7 @@ class Map extends Component {
     console.log(`this.drawRoom() took: ${after - before}ms`)
   }
 
-  drawMap () {
+  drawMap() {
     const before = Date.now()
 
     const { map, sprites } = this.props
@@ -117,12 +119,12 @@ class Map extends Component {
     console.log(`this.drawMap() took: ${after - before}ms`)
   }
 
-  componentDidUpdate () {
+  componentDidUpdate() {
     this.drawRoom()
     this.drawMap()
   }
 
-  handleOnMouseDown (e) {
+  handleOnMouseDown(e) {
     this.setState({
       mouseDown: true
     })
@@ -130,20 +132,20 @@ class Map extends Component {
     this.drawSprite({ row: +row, col: +col })
   }
 
-  handleOnMouseEnter (e) {
+  handleOnMouseEnter(e) {
     if (this.state.mouseDown) {
       const { row, col } = e.target.dataset
       this.drawSprite({ row: +row, col: +col })
     }
   }
 
-  handleOnMouseUp () {
+  handleOnMouseUp() {
     this.setState({
       mouseDown: false
     })
   }
 
-  handleOnTouchMove (e) {
+  handleOnTouchMove(e) {
     if (this.state.mouseDown) {
       const touchLocation = e.changedTouches[0]
       const dataset = document.elementFromPoint(
@@ -157,15 +159,15 @@ class Map extends Component {
     }
   }
 
-  handleSpriteClick (spriteIndex) {
+  handleSpriteClick(spriteIndex) {
     this.setState({ spriteIndex, mode: '+' })
   }
 
-  handleRoomClick (roomIndex) {
+  handleRoomClick(roomIndex) {
     this.setState({ roomIndex })
   }
 
-  drawSprite ({ row, col }) {
+  drawSprite({ row, col }) {
     const { roomIndex, spriteIndex, mode } = this.state
     const { updateMap } = this.props
     const map = this.getCurrentRoom()
@@ -175,30 +177,30 @@ class Map extends Component {
     updateMap(newMap)
   }
 
-  getCurrentRoom () {
+  getCurrentRoom() {
     const { map } = this.props
     return map.length ? map : Map.createBlankMap()
   }
 
-  setMode (mode) {
+  setMode(mode) {
     this.setState({
       mode
     })
   }
 
-  render () {
+  render() {
     const { roomIndex, spriteIndex, mode } = this.state
     const { map } = this.props
     return (
       <div
         onMouseUp={this.handleOnMouseUp}
         onTouchEnd={this.handleOnMouseUp}
-        className='Map two-rows-and-grid'
+        className="Map two-rows-and-grid"
       >
-        <div className='main'>
-          <div className='MapEditor'>
-            <div className='room-and-tools'>
-              <div className='room'>
+        <div className="main">
+          <div className="MapEditor">
+            <div className="room-and-tools">
+              <div className="room">
                 <table>
                   <tbody>
                     {_.range(16).map(row => (
@@ -217,7 +219,7 @@ class Map extends Component {
                                 onMouseEnter={this.handleOnMouseEnter}
                                 onTouchStart={this.handleOnMouseDown}
                                 onTouchMove={this.handleOnTouchMove}
-                                className='background-'
+                                className="background-"
                               >
                                 {_.isNil(sprite) ? 'x' : ''}
                               </button>
@@ -236,7 +238,7 @@ class Map extends Component {
                   }}
                 />
               </div>
-              <div className='tools'>
+              <div className="tools">
                 <button
                   className={classNames('button', {
                     active: mode === '+'
@@ -260,8 +262,8 @@ class Map extends Component {
                 </button>
               </div>
             </div>
-            <div className='sprites-and-map'>
-              <div className='sprites'>
+            <div className="sprites-and-map">
+              <div className="sprites">
                 <table>
                   <tbody>
                     {_.range(8).map(row => (
@@ -297,7 +299,7 @@ class Map extends Component {
                   }}
                 />
               </div>
-              <div className='map'>
+              <div className="map">
                 <table>
                   <tbody>
                     {_.range(4).map(row => (

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import _ from 'lodash'
 import classNames from 'classnames'
-import canvasAPI from '../iframe/src/contextCanvasAPI/index.js'
+import canvasAPI from '../iframe/src/frameBufferCanvasAPI/index.js'
+import pixelData from '../iframe/src/frameBufferCanvasAPI/pixelData.js'
 import actions from '../actions/actions.js'
 
 const mapStateToProps = ({ sprites, map }) => ({ sprites, map })
@@ -20,8 +21,12 @@ class Map extends Component {
     this.handleOnTouchMove = this.handleOnTouchMove.bind(this)
     this.handleSpriteClick = this.handleSpriteClick.bind(this)
     this.handleRoomClick = this.handleRoomClick.bind(this)
+
+    this.spritePixelData = pixelData({ width: 128, height: 64 });
     this.drawSprite = this.drawSprite.bind(this)
+    this.roomPixelData = pixelData({ width: 128, height: 128 });
     this.drawRoom = this.drawRoom.bind(this)
+    this.mapPixelData = pixelData({ width: 128 * 8, height: 128 * 4});
     this.drawMap = this.drawMap.bind(this)
     this.getCurrentRoom = this.getCurrentRoom.bind(this)
     this.setMode = this.setMode.bind(this)
@@ -44,7 +49,7 @@ class Map extends Component {
     const { sprites } = this.props
 
     this.spriteCanvasAPI = canvasAPI({
-      ctx: this._spriteCanvas.getContext('2d'),
+      pixels: this.spritePixelData.pixels,
       width: 128,
       height: 64,
       sprites
@@ -56,6 +61,7 @@ class Map extends Component {
       const col = key % 16
       this.spriteCanvasAPI.sprite(col * 8, row * 8, key)
     })
+    this.spritePixelData.writePixelDataToCanvas(this._spriteCanvas.getContext('2d'))
   }
 
   drawRoom () {
@@ -65,7 +71,7 @@ class Map extends Component {
     const { roomIndex } = this.state
 
     this.roomCanvasAPI = canvasAPI({
-      ctx: this._roomCanvas.getContext('2d'),
+      pixels: this.roomPixelData.pixels,
       width: 128,
       height: 128,
       sprites
@@ -81,6 +87,7 @@ class Map extends Component {
         this.roomCanvasAPI.sprite(colN * 8, rowN * 8, sprite)
       })
     })
+    this.roomPixelData.writePixelDataToCanvas(this._roomCanvas.getContext('2d'))
 
     const after = Date.now()
     console.log(`this.drawRoom() took: ${after - before}ms`)
@@ -91,7 +98,7 @@ class Map extends Component {
 
     const { map, sprites } = this.props
     this.mapCanvasAPI = canvasAPI({
-      ctx: this._mapCanvas.getContext('2d'),
+      pixels: this.mapPixelData.pixels,
       width: 128 * 8,
       height: 128 * 4,
       sprites,
@@ -104,6 +111,7 @@ class Map extends Component {
         this.mapCanvasAPI.sprite(colNumber * 8, rowNumber * 8, col)
       })
     })
+    this.mapPixelData.writePixelDataToCanvas(this._mapCanvas.getContext('2d'))
 
     const after = Date.now()
     console.log(`this.drawMap() took: ${after - before}ms`)

--- a/src/iframe/src/Iframe.js
+++ b/src/iframe/src/Iframe.js
@@ -213,7 +213,7 @@ class Iframe extends Component {
       sound: true
     }
 
-    this._pixelData = pixelData({ width: CANVAS_SIZE, height: CANVAS_SIZE})
+    this._pixelData = pixelData({ width: CANVAS_SIZE, height: CANVAS_SIZE })
   }
 
   // The following event listeners add/remove css classes from the DOM elements,
@@ -582,9 +582,7 @@ class Iframe extends Component {
       // and try fetching the gist.
       window
         .fetch(
-          `${process.env.REACT_APP_NOW}/gist/${
-            window.SCRIPT_8_EMBEDDED_GIST_ID
-          }`
+          `${process.env.REACT_APP_NOW}/gist/${window.SCRIPT_8_EMBEDDED_GIST_ID}`
         )
         .then(response => response.json())
         .then(json => {

--- a/src/iframe/src/Iframe.js
+++ b/src/iframe/src/Iframe.js
@@ -18,6 +18,7 @@ import bios from './utils/bios.js'
 import StateMachine from 'javascript-state-machine'
 import soundAPI from './soundAPI/index.js'
 import { default as frameBufferCanvasAPI } from './frameBufferCanvasAPI/index.js'
+import pixelData from './frameBufferCanvasAPI/pixelData.js'
 import trimCanvas from './contextCanvasAPI/trimCanvas.js'
 import validateToken from './validateToken.js'
 import getUserInput, { allowedKeys } from './getUserInput.js'
@@ -212,25 +213,7 @@ class Iframe extends Component {
       sound: true
     }
 
-    // Pixel data has the actual image data object which can be passed to putImageData.
-    this._pixelData = new ImageData(CANVAS_SIZE, CANVAS_SIZE)
-
-    // This contains the actual binary data for setting on _pixelData. It cannot
-    // be accessed directly, but is instead modified through TypedArrays such as
-    // Uint8ClampedArray and Uint32Array. Both the TypedArrays below refer to
-    // the same backing buffer, so modifying values via one will be reflected in
-    // the other.
-    this._pixelBuffer = new ArrayBuffer(4 * CANVAS_SIZE * CANVAS_SIZE)
-
-    // The pixelBytes array is only used to set the data in the _pixelData
-    // object. ImageData only has an Uint8ClampedArray to access the underlying
-    // bytes, so a Uint8ClampedArray must be kept around to copy the data.
-    this._pixelBytes = new Uint8ClampedArray(this._pixelBuffer)
-
-    // It turns out that setting pixels all at once via a single integer is much
-    // faster than setting each byte individually. So the pixel data is only
-    // ever modified via the Uint32Array for performance reasons.
-    this._pixelIntegers = new Uint32Array(this._pixelBuffer)
+    this._pixelData = pixelData({ width: CANVAS_SIZE, height: CANVAS_SIZE})
   }
 
   // The following event listeners add/remove css classes from the DOM elements,
@@ -416,7 +399,7 @@ class Iframe extends Component {
         Array,
         log: this.addLog,
         ...canvasAPI({
-          pixels: this._pixelIntegers,
+          pixels: this._pixelData.pixels,
           ctx: this._canvas.getContext('2d'),
           width: CANVAS_SIZE,
           height: CANVAS_SIZE,
@@ -444,9 +427,7 @@ class Iframe extends Component {
 
   // Writes pixel data buffer to canvas.
   writePixelDataToCanvas() {
-    this._pixelData.data.set(this._pixelBytes)
-    const ctx = this._canvas.getContext('2d')
-    ctx.putImageData(this._pixelData, 0, 0)
+    this._pixelData.writePixelDataToCanvas(this._canvas.getContext('2d'))
   }
 
   // Calls window.draw(state) .
@@ -1112,7 +1093,7 @@ class Iframe extends Component {
           if (buttons.length !== canvases.length) {
             actors.forEach((actor, i) => {
               // Fill the buffer with 0.
-              this._pixelIntegers.fill(0)
+              this._pixelData.pixels.fill(0)
 
               // Draw this actor on the center of the screen.
               window.drawActors({

--- a/src/iframe/src/frameBufferCanvasAPI/pixelData.js
+++ b/src/iframe/src/frameBufferCanvasAPI/pixelData.js
@@ -1,6 +1,4 @@
-const pixelData = ({
-  width, height
-}) => {
+const pixelData = ({ width, height }) => {
   // Pixel data has the actual image data object which can be passed to putImageData.
   const _pixelData = new ImageData(width, height)
 
@@ -21,15 +19,15 @@ const pixelData = ({
   // ever modified via the Uint32Array for performance reasons.
   const _pixelIntegers = new Uint32Array(_pixelBuffer)
 
-  const writePixelDataToCanvas = (ctx) => {
+  const writePixelDataToCanvas = ctx => {
     _pixelData.data.set(_pixelBytes)
     ctx.putImageData(_pixelData, 0, 0)
-  };
+  }
 
   return {
     pixels: _pixelIntegers,
     writePixelDataToCanvas
-  };
-};
+  }
+}
 
-export default pixelData;
+export default pixelData

--- a/src/iframe/src/frameBufferCanvasAPI/pixelData.js
+++ b/src/iframe/src/frameBufferCanvasAPI/pixelData.js
@@ -1,0 +1,35 @@
+const pixelData = ({
+  width, height
+}) => {
+  // Pixel data has the actual image data object which can be passed to putImageData.
+  const _pixelData = new ImageData(width, height)
+
+  // This contains the actual binary data for setting on _pixelData. It cannot
+  // be accessed directly, but is instead modified through TypedArrays such as
+  // Uint8ClampedArray and Uint32Array. Both the TypedArrays below refer to
+  // the same backing buffer, so modifying values via one will be reflected in
+  // the other.
+  const _pixelBuffer = new ArrayBuffer(4 * width * height)
+
+  // The pixelBytes array is only used to set the data in the _pixelData
+  // object. ImageData only has an Uint8ClampedArray to access the underlying
+  // bytes, so a Uint8ClampedArray must be kept around to copy the data.
+  const _pixelBytes = new Uint8ClampedArray(_pixelBuffer)
+
+  // It turns out that setting pixels all at once via a single integer is much
+  // faster than setting each byte individually. So the pixel data is only
+  // ever modified via the Uint32Array for performance reasons.
+  const _pixelIntegers = new Uint32Array(_pixelBuffer)
+
+  const writePixelDataToCanvas = (ctx) => {
+    _pixelData.data.set(_pixelBytes)
+    ctx.putImageData(_pixelData, 0, 0)
+  };
+
+  return {
+    pixels: _pixelIntegers,
+    writePixelDataToCanvas
+  };
+};
+
+export default pixelData;


### PR DESCRIPTION
This PR swaps the map container to use the frame buffer API for graphics rendering instead of the slower context api. This speeds things up significantly.

In doing so I noticed that there was a bunch of shared code for setting up the pixel data. So I extracted that into a pixelData file which handles constructing of the typed buffers and rendering of the buffers to a given canvas context.